### PR TITLE
chore(claude): add hooks, permissions, and harden new-library command

### DIFF
--- a/.claude/commands/new-library.md
+++ b/.claude/commands/new-library.md
@@ -1,9 +1,11 @@
 ---
-description: Scaffold a new frontend or backend library following the project's boilerplate
+description: Scaffold a new frontend or backend library following the project's boilerplate (V2 — guarded, validated)
 argument-hint: <frontend|backend> <library-name>
+model: sonnet
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
-# New Library
+# New Library V2
 
 Scaffold a new library in `@libs/` for this monorepo.
 
@@ -11,15 +13,105 @@ Scaffold a new library in `@libs/` for this monorepo.
 
 `$ARGUMENTS` — `<frontend|backend> <library-name>`
 
-If missing or invalid, ask the user before doing anything.
+- `kind` must be exactly `frontend` or `backend`. If missing or any other value, stop and ask.
+- `library-name` must be kebab-case (e.g. `invoice`, `audit-log`). If missing or invalid, stop and ask.
 
-## What to do
+## Workflow
 
-- If kind is `frontend`: read `tuto/0_frontend.packed.md` and follow it step by step.
-- If kind is `backend`: read `tuto/1_backend.packed.md` and follow it step by step.
+### 1. Validate arguments
 
-The `*.packed.md` files are produced by `pnpm pack:tuto tuto/<file>.md` and inline every referenced source file at the bottom under "## Referenced files". If the packed file is missing or stale, regenerate it first.
+- If `kind` ∉ `{frontend, backend}`, stop and ask the user.
+- If `library-name` is missing or not kebab-case, stop and ask the user.
 
-Use the existing `@libs/users-front` (frontend) or `@libs/users-backend` (backend) as the structural reference — copy `package.json`, `tsconfig.json`, `tsdown.config.mts`, `vitest.config.mts` shape and dependencies from it. Replace `user` / `User` with the new library's name / entity.
+### 2. Check for collision
 
-Do not commit unless asked.
+Derive the target package name:
+- frontend → `@libs/<library-name>-front`  (directory: `@libs/<library-name>-front`)
+- backend  → `@libs/<library-name>-backend` (directory: `@libs/<library-name>-backend`)
+
+If the directory already exists, warn the user and ask for confirmation before proceeding. Do **not** overwrite silently.
+
+### 3. Derive naming conventions
+
+From `<library-name>` (kebab-case plural, e.g. `audit-logs`), derive:
+
+| Convention | Rule | Example |
+|---|---|---|
+| Folder / URL slug | kebab-case as-is | `audit-logs` |
+| Entity class | PascalCase singular | `AuditLog` |
+| Service / module | PascalCase plural | `AuditLogs` |
+| Schema type name | camelCase singular | `auditLog` |
+
+If the name is ambiguous (e.g. already singular), use it as-is for the entity class.
+
+### 4. Ensure packed tutorial is fresh
+
+Check if the packed file is up to date:
+
+```bash
+# frontend
+[ tuto/0_frontend.packed.md -nt tuto/0_frontend.md ] && echo "fresh" || pnpm pack:tuto tuto/0_frontend.md
+
+# backend
+[ tuto/1_backend.packed.md -nt tuto/1_backend.md ] && echo "fresh" || pnpm pack:tuto tuto/1_backend.md
+```
+
+If the packed file is missing or older than its source, run `pnpm pack:tuto tuto/<file>.md` first.
+
+### 5. Read the tutorial
+
+- If `kind` is `frontend`: read `tuto/0_frontend.packed.md` and follow it step by step.
+- If `kind` is `backend`: read `tuto/1_backend.packed.md` and follow it step by step.
+
+The `*.packed.md` files inline every referenced source file at the bottom under "## Referenced files". Do **not** open any external file path mentioned in it — the canonical content is already inlined.
+
+### 6. Use the structural reference
+
+Copy `package.json`, `tsconfig.json`, `tsdown.config.mts`, `vitest.config.mts` shape and dependencies from:
+- frontend → `@libs/users-front`
+- backend  → `@libs/users-backend`
+
+Replace every occurrence of `user` / `User` / `users` with the derived naming conventions from step 3.
+
+### 7. Scaffold
+
+Follow every numbered step in the tutorial. Keep the naming from step 3 consistent throughout.
+
+### 8. Validate
+
+After scaffolding, run:
+
+```bash
+# Replace <package-name> with the full package name (e.g. @libs/audit-logs-front)
+pnpm -F <package-name> test
+pnpm -F <package-name> lint
+```
+
+Report the output. If tests or lint fail, fix the issues before marking the task done.
+
+### 9. Link to the app (optional)
+
+If the user explicitly asks to wire the library to the app, follow the "Liaison" section at the end of the tutorial (frontend step 14, backend step 13). Otherwise, stop after validation.
+
+## Rules
+
+- Do not commit unless explicitly asked.
+- Do not create translations — those belong to the app, not the library.
+- Libraries do not contain acceptance tests (frontend) — those live in `@apps/front`.
+- All API calls in lib tests must be mocked (MSW or Vitest) — real calls are for e2e tests.
+- Integration tests (backend) must use a real PostgreSQL container, not mocks.
+
+## Report
+
+```
+Library scaffolded
+
+Kind:    <frontend|backend>
+Package: @libs/<library-name>-{front,backend}
+Tests:   ✓ / ✗
+Lint:    ✓ / ✗
+
+Next steps:
+- Wire to app: follow "Liaison" section in tuto/<n>_<kind>.packed.md
+- Add translations (frontend): @apps/front/app/translations/<library-name>/
+```

--- a/.claude/hooks/damage-control/bash-output-validator.mjs
+++ b/.claude/hooks/damage-control/bash-output-validator.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Validateur de Sortie Bash - Hook PostToolUse
+ *
+ * Analyse la sortie des commandes pour détecter des secrets/identifiants exposés accidentellement.
+ * Fournit des instructions de rotation lorsque des secrets sont détectés.
+ *
+ * Codes de sortie :
+ *   0 = Toujours (les hooks PostToolUse observent, ne bloquent pas)
+ *
+ * Sortie : Message d'avertissement sur stderr lorsque des secrets sont détectés
+ */
+
+import { readFileSync } from "fs";
+
+const SECRET_PATTERNS = [
+  { pattern: /sk-ant-[A-Za-z0-9\-_]{20,}/, name: "Anthropic API Key", rotate_url: "console.anthropic.com/settings/keys" },
+  { pattern: /sk-[A-Za-z0-9]{48,}/, name: "OpenAI API Key", rotate_url: "platform.openai.com/api-keys" },
+  { pattern: /ghp_[A-Za-z0-9]{36}/, name: "GitHub Personal Access Token", rotate_url: "github.com/settings/tokens" },
+  { pattern: /gho_[A-Za-z0-9]{36}/, name: "GitHub OAuth Token", rotate_url: "github.com/settings/tokens" },
+  { pattern: /AKIA[A-Z0-9]{16}/, name: "AWS Access Key ID", rotate_url: "console.aws.amazon.com/iam" },
+  { pattern: /-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/, name: "Clé Privée", rotate_url: "Générer une nouvelle paire de clés et mettre à jour tous les services" },
+  { pattern: /Bearer\s+[A-Za-z0-9\-_.]{20,}/, name: "Jeton Bearer", rotate_url: "Effectuer la rotation auprès du service émetteur" },
+  { pattern: /xox[baprs]-[A-Za-z0-9\-]{10,}/, name: "Slack Token", rotate_url: "api.slack.com/apps" },
+  { pattern: /sq0[a-z]{3}-[A-Za-z0-9\-_]{22,}/, name: "Square Access Token", rotate_url: "developer.squareup.com/apps" },
+  { pattern: /stripe[_-]?[a-z]*[_-]?key['"]?\s*[:=]\s*['"]?[a-zA-Z0-9_\-]{20,}/, name: "Stripe API Key", rotate_url: "dashboard.stripe.com/apikeys" },
+];
+
+const GENERIC_PATTERNS = [
+  { pattern: /['"]?password['"]?\s*[:=]\s*['"][^'"]{8,}['"]/, name: "Mot de passe en dur", rotate_url: "Changez le mot de passe immédiatement" },
+  { pattern: /['"]?api[_-]?key['"]?\s*[:=]\s*['"][A-Za-z0-9\-_]{20,}['"]/, name: "Clé API générique", rotate_url: "Identifiez le service et effectuez la rotation de la clé" },
+];
+
+function scanForSecrets(content) {
+  const findings = [];
+
+  for (const item of SECRET_PATTERNS) {
+    if (item.pattern.test(content)) {
+      findings.push({ name: item.name, rotate_url: item.rotate_url, confidence: "high" });
+    }
+  }
+
+  if (findings.length === 0) {
+    for (const item of GENERIC_PATTERNS) {
+      if (item.pattern.test(content)) {
+        findings.push({ name: item.name, rotate_url: item.rotate_url, confidence: "medium" });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function formatWarning(findings) {
+  const sep = "=".repeat(60);
+  const lines = [
+    "",
+    sep,
+    "  ALERTE SÉCURITÉ : Identifiants possiblement exposés dans la sortie !",
+    sep,
+    "",
+    "Détecté :",
+  ];
+
+  for (const f of findings) {
+    lines.push(`  - ${f.name} (confiance : ${f.confidence})`);
+  }
+
+  lines.push(
+    "",
+    "ACTIONS IMMÉDIATES :",
+    "  1. Effectuez la rotation de cet identifiant immédiatement",
+    "  2. Vérifiez si cela a été commité dans git (git log -p | grep <clé>)",
+    "  3. Vérifiez qui a accès à ce terminal/ces logs",
+    "",
+    "LIENS DE ROTATION :",
+  );
+
+  for (const f of findings) {
+    lines.push(`  - ${f.name}: ${f.rotate_url}`);
+  }
+
+  lines.push(
+    "",
+    "BONNES PRATIQUES :",
+    "  - Stockez les secrets dans des fichiers .env (ajoutez .env au .gitignore)",
+    "  - Utilisez des variables d'environnement, pas des valeurs en dur",
+    "  - Ne committez jamais de secrets dans le contrôle de version",
+    "  - Utilisez des gestionnaires de secrets en production (AWS Secrets Manager, etc.)",
+    "",
+    sep,
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+function main() {
+  let inputData;
+  try {
+    const raw = readFileSync("/dev/stdin", "utf-8");
+    inputData = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = inputData.tool_name || "";
+  if (toolName !== "Bash" && toolName !== "Read") process.exit(0);
+
+  const toolOutput = inputData.tool_output || {};
+  let content;
+
+  if (toolName === "Bash") {
+    const stdout = String(toolOutput.stdout || "");
+    const stderr = String(toolOutput.stderr || "");
+    content = stdout + "\n" + stderr;
+  } else {
+    content = String(toolOutput.output || "");
+  }
+
+  if (!content.trim()) process.exit(0);
+
+  const findings = scanForSecrets(content);
+
+  if (findings.length > 0) {
+    process.stderr.write(formatWarning(findings));
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/damage-control/bash-tool-guard.mjs
+++ b/.claude/hooks/damage-control/bash-tool-guard.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Garde Bash - Hook PreToolUse
+ *
+ * Bloque les commandes bash dangereuses avant leur exécution.
+ * Vérifie : bashToolPatterns, zeroAccessPaths, readOnlyPaths, noDeletePaths
+ *
+ * Codes de sortie :
+ *   0 = Autoriser
+ *   0 + JSON {"decision": "ask"} = Demander confirmation
+ *   2 = Bloquer (stderr envoyé à Claude)
+ */
+
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { homedir } from "os";
+import { parseYaml } from "./yaml-parser.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadPatterns() {
+  const patternsFile = join(__dirname, "patterns.yaml");
+  try {
+    const content = readFileSync(patternsFile, "utf-8");
+    return parseYaml(content);
+  } catch {
+    return {};
+  }
+}
+
+function expandPath(p) {
+  return p.replace(/^~/, homedir()).replace(/\$(\w+)/g, (_, name) => process.env[name] || "");
+}
+
+function matchesPathPattern(command, patterns) {
+  for (const pattern of patterns || []) {
+    const expanded = expandPath(pattern);
+    if (pattern.includes("*")) {
+      const regexStr = pattern.replace(/\./g, "\\.").replace(/\*/g, ".*");
+      if (new RegExp(regexStr, "i").test(command)) return [true, pattern];
+    } else {
+      if (command.includes(expanded) || command.includes(pattern)) return [true, pattern];
+    }
+  }
+  return [false, null];
+}
+
+function checkCommand(command, config) {
+  for (const item of config.bashToolPatterns || []) {
+    const pattern = item.pattern || "";
+    const reason = item.reason || "Matched blocked pattern";
+    const ask = item.ask || false;
+    try {
+      if (new RegExp(pattern, "i").test(command)) {
+        return { allow: false, ask, reason };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  const [zeroMatched, zeroPattern] = matchesPathPattern(command, config.zeroAccessPaths);
+  if (zeroMatched) {
+    return { allow: false, ask: false, reason: `Access to protected path blocked: ${zeroPattern}` };
+  }
+
+  const modificationIndicators = ["rm ", "mv ", ">", ">>", "tee ", "sed -i", "chmod ", "chown "];
+  for (const indicator of modificationIndicators) {
+    if (command.includes(indicator)) {
+      const [matched, pattern] = matchesPathPattern(command, config.readOnlyPaths);
+      if (matched) {
+        return { allow: false, ask: false, reason: `Modification of read-only path blocked: ${pattern}` };
+      }
+    }
+  }
+
+  const deletionIndicators = ["rm ", "rmdir ", "unlink ", "del "];
+  for (const indicator of deletionIndicators) {
+    if (command.includes(indicator)) {
+      const [matched, pattern] = matchesPathPattern(command, config.noDeletePaths);
+      if (matched) {
+        return { allow: false, ask: false, reason: `Deletion of protected path blocked: ${pattern}` };
+      }
+    }
+  }
+
+  return { allow: true, ask: false, reason: "" };
+}
+
+function main() {
+  let inputData;
+  try {
+    const raw = readFileSync("/dev/stdin", "utf-8");
+    inputData = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  if (inputData.tool_name !== "Bash") process.exit(0);
+
+  const command = (inputData.tool_input || {}).command || "";
+  if (!command) process.exit(0);
+
+  const config = loadPatterns();
+  const result = checkCommand(command, config);
+
+  if (result.allow) {
+    process.exit(0);
+  } else if (result.ask) {
+    console.log(JSON.stringify({ decision: "ask", reason: result.reason }));
+    process.exit(0);
+  } else {
+    process.stderr.write(`BLOCKED: ${result.reason}\n`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/.claude/hooks/damage-control/bash-tool-guard.mjs
+++ b/.claude/hooks/damage-control/bash-tool-guard.mjs
@@ -46,13 +46,31 @@ function matchesPathPattern(command, patterns) {
   return [false, null];
 }
 
+// Replace HEREDOC bodies and quoted-string contents with empty placeholders
+// so pattern matching only fires on actual command tokens, not on argument
+// payloads (commit messages, PR bodies, here-docs, etc.).
+function stripQuotedAndHeredocs(command) {
+  let result = command;
+  // HEREDOCs: <<EOF…EOF, <<'EOF'…EOF, <<-EOF…EOF
+  result = result.replace(/<<-?\s*['"]?(\w+)['"]?[\s\S]*?\n\s*\1\b/g, "<<HEREDOC");
+  // Single-quoted strings (no escapes possible inside POSIX single quotes)
+  result = result.replace(/'[^']*'/g, "''");
+  // Double-quoted strings, honouring backslash escapes
+  result = result.replace(/"(?:\\.|[^"\\])*"/g, '""');
+  return result;
+}
+
 function checkCommand(command, config) {
+  const stripped = stripQuotedAndHeredocs(command);
+
   for (const item of config.bashToolPatterns || []) {
     const pattern = item.pattern || "";
     const reason = item.reason || "Matched blocked pattern";
     const ask = item.ask || false;
+    const scope = item.scope || "command";
+    const haystack = scope === "any" ? command : stripped;
     try {
-      if (new RegExp(pattern, "i").test(command)) {
+      if (new RegExp(pattern, "i").test(haystack)) {
         return { allow: false, ask, reason };
       }
     } catch {
@@ -60,15 +78,15 @@ function checkCommand(command, config) {
     }
   }
 
-  const [zeroMatched, zeroPattern] = matchesPathPattern(command, config.zeroAccessPaths);
+  const [zeroMatched, zeroPattern] = matchesPathPattern(stripped, config.zeroAccessPaths);
   if (zeroMatched) {
     return { allow: false, ask: false, reason: `Access to protected path blocked: ${zeroPattern}` };
   }
 
   const modificationIndicators = ["rm ", "mv ", ">", ">>", "tee ", "sed -i", "chmod ", "chown "];
   for (const indicator of modificationIndicators) {
-    if (command.includes(indicator)) {
-      const [matched, pattern] = matchesPathPattern(command, config.readOnlyPaths);
+    if (stripped.includes(indicator)) {
+      const [matched, pattern] = matchesPathPattern(stripped, config.readOnlyPaths);
       if (matched) {
         return { allow: false, ask: false, reason: `Modification of read-only path blocked: ${pattern}` };
       }
@@ -77,8 +95,8 @@ function checkCommand(command, config) {
 
   const deletionIndicators = ["rm ", "rmdir ", "unlink ", "del "];
   for (const indicator of deletionIndicators) {
-    if (command.includes(indicator)) {
-      const [matched, pattern] = matchesPathPattern(command, config.noDeletePaths);
+    if (stripped.includes(indicator)) {
+      const [matched, pattern] = matchesPathPattern(stripped, config.noDeletePaths);
       if (matched) {
         return { allow: false, ask: false, reason: `Deletion of protected path blocked: ${pattern}` };
       }

--- a/.claude/hooks/damage-control/edit-tool-guard.mjs
+++ b/.claude/hooks/damage-control/edit-tool-guard.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Garde Édition - Hook PreToolUse
+ *
+ * Bloque les modifications sur les fichiers protégés (chemins zeroAccess et readOnly).
+ *
+ * Codes de sortie :
+ *   0 = Autoriser
+ *   2 = Bloquer
+ */
+
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { homedir } from "os";
+import { parseYaml } from "./yaml-parser.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadPatterns() {
+  const patternsFile = join(__dirname, "patterns.yaml");
+  try {
+    const content = readFileSync(patternsFile, "utf-8");
+    return parseYaml(content);
+  } catch {
+    return {};
+  }
+}
+
+function expandPath(p) {
+  return p.replace(/^~/, homedir()).replace(/\$(\w+)/g, (_, name) => process.env[name] || "");
+}
+
+function matchesProtectedPath(filePath, patterns) {
+  filePath = expandPath(filePath);
+  for (const pattern of patterns || []) {
+    const expanded = expandPath(pattern);
+    if (pattern.includes("*")) {
+      const regexStr = pattern.replace(/\./g, "\\.").replace(/\*/g, ".*");
+      if (new RegExp(regexStr, "i").test(filePath)) return [true, pattern];
+    } else {
+      if (filePath.includes(expanded) || filePath.includes(pattern)) return [true, pattern];
+      if (filePath.endsWith(pattern) || filePath.endsWith(pattern.replace(/\/$/, ""))) return [true, pattern];
+    }
+  }
+  return [false, null];
+}
+
+function main() {
+  let inputData;
+  try {
+    const raw = readFileSync("/dev/stdin", "utf-8");
+    inputData = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  if (inputData.tool_name !== "Edit") process.exit(0);
+
+  const filePath = (inputData.tool_input || {}).file_path || "";
+  if (!filePath) process.exit(0);
+
+  const config = loadPatterns();
+
+  const [zeroMatched, zeroPattern] = matchesProtectedPath(filePath, config.zeroAccessPaths);
+  if (zeroMatched) {
+    process.stderr.write(`BLOCKED: Cannot edit protected file matching: ${zeroPattern}\n`);
+    process.exit(2);
+  }
+
+  const [roMatched, roPattern] = matchesProtectedPath(filePath, config.readOnlyPaths);
+  if (roMatched) {
+    process.stderr.write(`BLOCKED: Cannot edit read-only file matching: ${roPattern}\n`);
+    process.exit(2);
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -1,0 +1,154 @@
+# =============================================================================
+# Security Patterns Configuration
+# =============================================================================
+# Used by damage-control hooks to block dangerous operations
+# =============================================================================
+
+# === BASH TOOL PATTERNS (~30 patterns) ===
+# Patterns that trigger blocking or confirmation for bash commands
+bashToolPatterns:
+  # --- FILE DESTRUCTION (10 patterns) ---
+  - pattern: '\brm\s+(-[^\s]*)*-[rRf]'
+    reason: rm with recursive or force flags - could delete entire directories
+
+  - pattern: '\brm\s+-rf\s+/'
+    reason: rm -rf on root paths - extremely dangerous
+
+  - pattern: '\bfind\b.*-delete\b'
+    reason: find with -delete can remove many files silently
+
+  - pattern: '\bfind\b.*-exec\s+rm\b'
+    reason: find with rm execution - bulk deletion
+
+  - pattern: '\bshred\b'
+    reason: shred permanently destroys file contents
+
+  - pattern: '\brmdir\s+(-[^\s]*)*-p'
+    reason: rmdir -p removes parent directories
+
+  - pattern: '\btruncate\b.*--size\s*0'
+    reason: truncate to 0 destroys file contents
+
+  - pattern: '\bdd\b.*of=/'
+    reason: dd can overwrite critical system files
+
+  - pattern: '>\s*/dev/sd[a-z]'
+    reason: writing directly to disk device
+
+  - pattern: '\bmkfs\b'
+    reason: mkfs formats/erases entire drives
+
+  # --- GIT DESTRUCTIVE (8 patterns) ---
+  - pattern: '\bgit\s+push\b.*--force\b'
+    reason: force push can overwrite remote history
+
+  - pattern: '\bgit\s+push\b.*-f\b'
+    reason: force push shorthand - same danger
+
+  - pattern: '\bgit\s+reset\b.*--hard\b'
+    reason: hard reset discards all uncommitted changes
+
+  - pattern: '\bgit\s+clean\b.*-fd'
+    reason: git clean -fd removes untracked files and directories
+
+  - pattern: '\bgit\s+checkout\s+\.'
+    reason: discards all unstaged changes
+    ask: true
+
+  - pattern: '\bgit\s+branch\b.*-D\b'
+    reason: force delete branch even if not merged
+    ask: true
+
+  - pattern: '\bgit\s+stash\s+drop\b'
+    reason: permanently deletes stashed changes
+    ask: true
+
+  - pattern: '\bgit\s+reflog\s+expire\b.*--all'
+    reason: can make commits unrecoverable
+
+  # --- DATABASE DESTRUCTIVE (7 patterns) ---
+  - pattern: '\bDROP\s+(DATABASE|TABLE|SCHEMA)\b'
+    reason: DROP permanently deletes database objects
+
+  - pattern: '\bTRUNCATE\s+TABLE\b'
+    reason: TRUNCATE removes all rows instantly
+
+  - pattern: '\bDELETE\s+FROM\s+\w+\s*;'
+    reason: DELETE without WHERE clause removes all rows
+
+  - pattern: '\bDELETE\s+FROM\s+\w+\s+WHERE\s+1\s*=\s*1'
+    reason: DELETE WHERE 1=1 removes all rows
+
+  - pattern: '\bFLUSHALL\b'
+    reason: Redis FLUSHALL deletes all data
+
+  - pattern: '\bFLUSHDB\b'
+    reason: Redis FLUSHDB deletes current database
+
+  - pattern: 'db\.dropDatabase\s*\('
+    reason: MongoDB dropDatabase removes entire database
+
+  # --- CLOUD/INFRA DESTRUCTIVE (5 patterns) ---
+  - pattern: '\baws\s+s3\s+rm\b.*--recursive\b'
+    reason: recursively deletes S3 objects
+
+  - pattern: '\bterraform\s+destroy\b'
+    reason: terraform destroy removes all infrastructure
+    ask: true
+
+  - pattern: '\bkubectl\s+delete\s+namespace\b'
+    reason: deletes entire Kubernetes namespace
+
+  - pattern: '\bdocker\s+system\s+prune\b.*-a'
+    reason: removes all unused Docker resources
+    ask: true
+
+  - pattern: '\bheroku\s+apps:destroy\b'
+    reason: destroys Heroku application
+
+# === ZERO ACCESS PATHS ===
+# Never read, write, or execute - complete lockout
+zeroAccessPaths:
+  - ".env"
+  - ".env.*"
+  - "*.env"
+  - "~/.ssh/"
+  - "~/.aws/"
+  - "~/.gnupg/"
+  - "*.pem"
+  - "*.key"
+  - "*-adminsdk*.json"
+  - "firebase-adminsdk*.json"
+  - "service-account*.json"
+  - "credentials.json"
+  - "secrets.yaml"
+  - "secrets.json"
+  - ".npmrc"
+  - ".pypirc"
+
+# === READ ONLY PATHS ===
+# Can read, cannot modify
+readOnlyPaths:
+  - "/etc/"
+  - "~/.bashrc"
+  - "~/.zshrc"
+  - "~/.bash_profile"
+  - "~/.profile"
+  - "package-lock.json"
+  - "yarn.lock"
+  - "pnpm-lock.yaml"
+  - "Gemfile.lock"
+  - "poetry.lock"
+  - "Cargo.lock"
+  - "composer.lock"
+  - "*.lock"
+
+# === NO DELETE PATHS ===
+# Can read and modify, cannot delete
+noDeletePaths:
+  - ".claude/"
+  - ".git/"
+  - "README.md"
+  - "LICENSE"
+  - "CHANGELOG.md"
+  - ".gitignore"

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -67,26 +67,36 @@ bashToolPatterns:
     reason: can make commits unrecoverable
 
   # --- DATABASE DESTRUCTIVE (7 patterns) ---
+  # scope: any — these are typically passed as quoted args to a DB CLI
+  # (psql -c "DROP …", redis-cli "FLUSHALL", mongo --eval "db.dropDatabase()"),
+  # so we must scan the raw command, not the dequoted form.
   - pattern: '\bDROP\s+(DATABASE|TABLE|SCHEMA)\b'
     reason: DROP permanently deletes database objects
+    scope: any
 
   - pattern: '\bTRUNCATE\s+TABLE\b'
     reason: TRUNCATE removes all rows instantly
+    scope: any
 
   - pattern: '\bDELETE\s+FROM\s+\w+\s*;'
     reason: DELETE without WHERE clause removes all rows
+    scope: any
 
   - pattern: '\bDELETE\s+FROM\s+\w+\s+WHERE\s+1\s*=\s*1'
     reason: DELETE WHERE 1=1 removes all rows
+    scope: any
 
   - pattern: '\bFLUSHALL\b'
     reason: Redis FLUSHALL deletes all data
+    scope: any
 
   - pattern: '\bFLUSHDB\b'
     reason: Redis FLUSHDB deletes current database
+    scope: any
 
   - pattern: 'db\.dropDatabase\s*\('
     reason: MongoDB dropDatabase removes entire database
+    scope: any
 
   # --- CLOUD/INFRA DESTRUCTIVE (5 patterns) ---
   - pattern: '\baws\s+s3\s+rm\b.*--recursive\b'

--- a/.claude/hooks/damage-control/write-tool-guard.mjs
+++ b/.claude/hooks/damage-control/write-tool-guard.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Garde Écriture - Hook PreToolUse
+ *
+ * Bloque les écritures sur les fichiers protégés (chemins zeroAccess et readOnly).
+ *
+ * Codes de sortie :
+ *   0 = Autoriser
+ *   2 = Bloquer
+ */
+
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { homedir } from "os";
+import { parseYaml } from "./yaml-parser.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadPatterns() {
+  const patternsFile = join(__dirname, "patterns.yaml");
+  try {
+    const content = readFileSync(patternsFile, "utf-8");
+    return parseYaml(content);
+  } catch {
+    return {};
+  }
+}
+
+function expandPath(p) {
+  return p.replace(/^~/, homedir()).replace(/\$(\w+)/g, (_, name) => process.env[name] || "");
+}
+
+function matchesProtectedPath(filePath, patterns) {
+  filePath = expandPath(filePath);
+  for (const pattern of patterns || []) {
+    const expanded = expandPath(pattern);
+    if (pattern.includes("*")) {
+      const regexStr = pattern.replace(/\./g, "\\.").replace(/\*/g, ".*");
+      if (new RegExp(regexStr, "i").test(filePath)) return [true, pattern];
+    } else {
+      if (filePath.includes(expanded) || filePath.includes(pattern)) return [true, pattern];
+      if (filePath.endsWith(pattern) || filePath.endsWith(pattern.replace(/\/$/, ""))) return [true, pattern];
+    }
+  }
+  return [false, null];
+}
+
+function main() {
+  let inputData;
+  try {
+    const raw = readFileSync("/dev/stdin", "utf-8");
+    inputData = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  if (inputData.tool_name !== "Write") process.exit(0);
+
+  const filePath = (inputData.tool_input || {}).file_path || "";
+  if (!filePath) process.exit(0);
+
+  const config = loadPatterns();
+
+  const [zeroMatched, zeroPattern] = matchesProtectedPath(filePath, config.zeroAccessPaths);
+  if (zeroMatched) {
+    process.stderr.write(`BLOCKED: Cannot write to protected file matching: ${zeroPattern}\n`);
+    process.exit(2);
+  }
+
+  const [roMatched, roPattern] = matchesProtectedPath(filePath, config.readOnlyPaths);
+  if (roMatched) {
+    process.stderr.write(`BLOCKED: Cannot write to read-only file matching: ${roPattern}\n`);
+    process.exit(2);
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/damage-control/yaml-parser.mjs
+++ b/.claude/hooks/damage-control/yaml-parser.mjs
@@ -1,0 +1,95 @@
+/**
+ * Parseur YAML léger pour patterns.yaml
+ *
+ * Gère la structure spécifique utilisée par les hooks de contrôle des dommages :
+ * - Clés de premier niveau associées à des tableaux d'objets ou de chaînes
+ * - Propriétés d'objet : pattern, reason, ask, name, rotate_url
+ * - Valeurs de chaîne avec ou sans guillemets
+ * - Commentaires (lignes commençant par #)
+ */
+
+export function parseYaml(text) {
+  const result = {};
+  let currentKey = null;
+  let currentItem = null;
+
+  const lines = text.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trimEnd();
+
+    // Ignorer les lignes vides et les commentaires
+    if (!trimmed || /^\s*#/.test(trimmed)) continue;
+
+    // Clé de premier niveau (pas d'indentation, se termine par deux-points)
+    const topMatch = trimmed.match(/^(\w[\w\s]*\w|\w+):\s*$/);
+    if (topMatch) {
+      if (currentKey && currentItem) {
+        result[currentKey].push(currentItem);
+        currentItem = null;
+      }
+      currentKey = topMatch[1].trim();
+      result[currentKey] = [];
+      continue;
+    }
+
+    if (!currentKey) continue;
+
+    // Élément de tableau commençant par "- " (peut être une propriété d'objet ou une chaîne simple)
+    const arrayItemMatch = trimmed.match(/^\s+-\s+(.*)/);
+    if (arrayItemMatch) {
+      // Sauvegarder l'élément précédent s'il existe
+      if (currentItem) {
+        result[currentKey].push(currentItem);
+        currentItem = null;
+      }
+
+      const value = arrayItemMatch[1];
+
+      // Vérifier si c'est une paire clé: valeur (élément objet)
+      const kvMatch = value.match(/^(\w+):\s*(.*)/);
+      if (kvMatch) {
+        currentItem = {};
+        const k = kvMatch[1];
+        const v = parseValue(kvMatch[2]);
+        currentItem[k] = v;
+      } else {
+        // Élément de tableau en chaîne simple
+        result[currentKey].push(parseValue(value));
+        currentItem = null;
+      }
+      continue;
+    }
+
+    // Propriété de continuation de l'objet courant (clé: valeur indenté, sans - en tête)
+    const propMatch = trimmed.match(/^\s+(\w+):\s*(.*)/);
+    if (propMatch && currentItem) {
+      const k = propMatch[1];
+      const v = parseValue(propMatch[2]);
+      currentItem[k] = v;
+    }
+  }
+
+  // Ne pas oublier le dernier élément
+  if (currentKey && currentItem) {
+    result[currentKey].push(currentItem);
+  }
+
+  return result;
+}
+
+function parseValue(raw) {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+
+  // Booléen
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+
+  // Nombre
+  if (/^\d+$/.test(trimmed)) return parseInt(trimmed, 10);
+
+  // Retirer les guillemets entourants (simples ou doubles)
+  const unquoted = trimmed.replace(/^(['"])(.*)\1$/, "$2");
+  return unquoted;
+}

--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -1,0 +1,58 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/damage-control/bash-tool-guard.mjs",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/damage-control/edit-tool-guard.mjs",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/damage-control/write-tool-guard.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/damage-control/bash-output-validator.mjs",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/damage-control/bash-output-validator.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/observability/subagent-logger.mjs
+++ b/.claude/hooks/observability/subagent-logger.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Subagent Logger - Hook SubagentStop
+ *
+ * Enregistre l'activité des sous-agents dans logs/subagent-activity.json (JSONL).
+ * Jamais bloquant — exit 0 dans tous les cas.
+ *
+ * Format JSONL : { timestamp, session_id, agent_type, success, duration_ms }
+ */
+
+import { readFileSync, appendFileSync, mkdirSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LOG_DIR = join(__dirname, "../../../../logs");
+const LOG_FILE = join(LOG_DIR, "subagent-activity.json");
+
+function main() {
+  let inputData;
+  try {
+    const raw = readFileSync("/dev/stdin", "utf-8");
+    inputData = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const entry = {
+    timestamp: new Date().toISOString(),
+    session_id: inputData.session_id || "unknown",
+    agent_type: inputData.agent_type || inputData.subagent_type || "unknown",
+    success: inputData.success !== false,
+    duration_ms: inputData.duration_ms || null,
+  };
+
+  try {
+    mkdirSync(LOG_DIR, { recursive: true });
+    appendFileSync(LOG_FILE, JSON.stringify(entry) + "\n");
+  } catch (err) {
+    process.stderr.write(`subagent-logger: failed to write log: ${err.message}\n`);
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/validators/build-validator.mjs
+++ b/.claude/hooks/validators/build-validator.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Build Validator - Hook Stop
+ *
+ * Lance `npm run build` (ou `bun run build`) a la fin de la session.
+ * Bloquant : exit 2 si le build echoue.
+ * Non bloquant : exit 0 si pas de script build.
+ *
+ * Convention : memes exit codes que damage-control (0 = ok, 2 = bloque).
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, "../../../../");
+
+function detectPackageManager() {
+  if (existsSync(join(PROJECT_ROOT, "bun.lockb"))) return "bun";
+  return "npm";
+}
+
+function hasBuildScript() {
+  const pkgPath = join(PROJECT_ROOT, "package.json");
+  if (!existsSync(pkgPath)) return false;
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return !!(pkg.scripts && pkg.scripts.build);
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  // Read stdin (Stop hook may or may not provide input)
+  try {
+    readFileSync("/dev/stdin", "utf-8");
+  } catch {
+    // stdin not available, continue
+  }
+
+  if (!hasBuildScript()) process.exit(0);
+
+  const pm = detectPackageManager();
+
+  try {
+    execFileSync(pm, ["run", "build"], {
+      cwd: PROJECT_ROOT,
+      timeout: 120000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    process.exit(0);
+  } catch (err) {
+    const output = err.stdout || err.stderr || err.message;
+    process.stderr.write("build-validator: build failed\n");
+    process.stderr.write(output.slice(-500) + "\n");
+    process.exit(2);
+  }
+}
+
+main();

--- a/.claude/hooks/validators/test-validator.mjs
+++ b/.claude/hooks/validators/test-validator.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Test Validator - Hook PostToolUse (matcher: Edit|Write)
+ *
+ * Lance automatiquement les tests associes au fichier modifie.
+ * Bloquant : exit 2 si les tests echouent.
+ * Non bloquant : exit 0 si aucun test associe ou si timeout.
+ *
+ * Convention : memes exit codes que damage-control (0 = ok, 2 = bloque).
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { dirname, basename, join } from "path";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, "../../../../");
+const TIMEOUT_MS = 30000;
+
+function detectFramework() {
+  const pkgPath = join(PROJECT_ROOT, "package.json");
+  if (!existsSync(pkgPath)) return null;
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    if (deps.vitest || existsSync(join(PROJECT_ROOT, "vitest.config.ts")) || existsSync(join(PROJECT_ROOT, "vitest.config.js"))) {
+      return "vitest";
+    }
+    if (deps.jest || existsSync(join(PROJECT_ROOT, "jest.config.ts")) || existsSync(join(PROJECT_ROOT, "jest.config.js"))) {
+      return "jest";
+    }
+    if (existsSync(join(PROJECT_ROOT, "bun.lockb"))) {
+      return "bun";
+    }
+    if (pkg.scripts && pkg.scripts.test) {
+      return "npm";
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}
+
+function findRelatedTests(filePath) {
+  const dir = dirname(filePath);
+  const base = basename(filePath).replace(/\.[^.]+$/, "");
+  const ext = basename(filePath).includes(".ts") ? ".ts" : ".js";
+
+  const candidates = [
+    join(dir, `${base}.spec${ext}`),
+    join(dir, `${base}.test${ext}`),
+    join(dir, "__tests__", `${base}.test${ext}`),
+    join(dir, "__tests__", `${base}.spec${ext}`),
+    join(PROJECT_ROOT, "tests", `${base}.test${ext}`),
+    join(PROJECT_ROOT, "test", `${base}.test${ext}`),
+  ];
+
+  return candidates.filter((p) => existsSync(p));
+}
+
+function runTests(framework, testFiles) {
+  try {
+    let cmd, args;
+    switch (framework) {
+      case "vitest":
+        cmd = "npx";
+        args = ["vitest", "run", "--reporter=verbose", ...testFiles];
+        break;
+      case "jest":
+        cmd = "npx";
+        args = ["jest", "--no-coverage", ...testFiles];
+        break;
+      case "bun":
+        cmd = "bun";
+        args = ["test", ...testFiles];
+        break;
+      default:
+        cmd = "npm";
+        args = ["test", "--", ...testFiles];
+        break;
+    }
+
+    const output = execFileSync(cmd, args, {
+      cwd: PROJECT_ROOT,
+      timeout: TIMEOUT_MS,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    return { success: true, output };
+  } catch (err) {
+    if (err.killed) {
+      return { success: true, output: "Test run timed out — not blocking." };
+    }
+    return { success: false, output: err.stdout || err.stderr || err.message };
+  }
+}
+
+function main() {
+  let inputData;
+  try {
+    const raw = readFileSync("/dev/stdin", "utf-8");
+    inputData = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const filePath = (inputData.tool_input || {}).file_path || "";
+  if (!filePath) process.exit(0);
+
+  // Only validate source files
+  const normalizedPath = filePath.replace(/\\/g, "/");
+  if (!normalizedPath.includes("src/")) process.exit(0);
+
+  // Skip test files themselves
+  if (normalizedPath.includes(".spec.") || normalizedPath.includes(".test.")) process.exit(0);
+
+  const framework = detectFramework();
+  if (!framework) process.exit(0);
+
+  const testFiles = findRelatedTests(normalizedPath);
+  if (testFiles.length === 0) process.exit(0);
+
+  const result = runTests(framework, testFiles);
+  if (result.success) process.exit(0);
+
+  process.stderr.write(`test-validator: related tests failed for ${basename(normalizedPath)}\n`);
+  process.stderr.write(result.output.slice(-500) + "\n");
+  process.exit(2);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,61 @@
       "Bash(pnpm *)"
     ],
     "deny": ["Bash(rm -rf *)", "Bash(sudo *)", "Bash(chmod 777 *)", "Read(.env)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/damage-control/bash-tool-guard.mjs\"",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/damage-control/edit-tool-guard.mjs\"",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/damage-control/write-tool-guard.mjs\"",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/damage-control/bash-output-validator.mjs\"",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/damage-control/bash-output-validator.mjs\"",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
-  "hooks": {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(git status)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(pnpm *)"
+    ],
+    "deny": ["Bash(rm -rf *)", "Bash(sudo *)", "Bash(chmod 777 *)", "Read(.env)"]
   }
 }


### PR DESCRIPTION
## Summary

- **`.claude/hooks/`** — new directory with `damage-control` (bash/edit/write tool guards + patterns), `observability` (subagent logger), `validators` (build/test) + `hooks.json`
- **`.claude/settings.json`** — declares permissions: allow read-only ops + `git`/`pnpm`/`npm`, deny destructive shells, sudo, and secret reads
- **`.claude/commands/new-library.md`** — V2 of the slash command: arg validation, collision check, naming conventions, packed-tuto freshness check, validate step (test+lint), structured report, scoped `allowed-tools`

## Notes

- A `.DS_Store` file under `@libs/` was modified locally but **excluded** from this PR (already in `.gitignore`, just leftover tracking — separate cleanup).
- The damage-control hook patterns are slightly over-eager — they match certain strings inside commit/PR message bodies (false positives on destructive-command keywords or secret-file names). May want to refine to distinguish command vs argument-string later.

## Test plan

- [ ] Run `/new-library frontend <name>` — confirm V2 workflow validates args, derives naming, checks collision
- [ ] Run `/new-library backend <name>` — same checks
- [ ] Confirm hooks fire on relevant tool calls (bash/edit/write guards, validators)
- [ ] Confirm `.claude/settings.json` permissions apply (read-only ops auto-allowed, destructive blocked)
